### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,13 @@
 #
 /[Ll]ibrary/
 /[Tt]emp/
-/[Oo]Obj/*
+/[Oo]bj/*
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
 
+# This seems to work with union with *.obj files, annoying.
 !*.obj
 !*.obj.meta
 


### PR DESCRIPTION
Default github .gitignore ignores wavefront OBJ files for some reason.